### PR TITLE
Fix conda channel priority for Azimuth/RuleSet3; update tutorial typos

### DIFF
--- a/R/basilisk.R
+++ b/R/basilisk.R
@@ -109,7 +109,7 @@ env_deepspcas9 <- BasiliskEnvironment(envname="deepspcas9__basilisk",
 env_rs3 <- BasiliskEnvironment(envname="rs3__basilisk",
                                pkgname="crisprScore",
                                packages=rs3_dependencies,
-                               channels = c("bioconda", "conda-forge"),
+                               channels = c("conda-forge","bioconda"),
                                pip=rs3_dependencies_pip)
 
 if (.Platform$OS.type!="windows"){

--- a/R/basilisk.R
+++ b/R/basilisk.R
@@ -84,7 +84,7 @@ env_azimuth <- BasiliskEnvironment(envname="azimuth_basilisk",
                                    pkgname="crisprScore",
                                    paths="python/azimuth",
                                    packages=azimuth_dependencies,
-                                   channels = c("bioconda", "conda-forge"),
+                                   channels = c("conda-forge", "bioconda"),
                                    pip=azimuth_dependencies_pip)
 
 env_lindel <- BasiliskEnvironment(envname="lindel_basilisk",

--- a/vignettes/crisprScore.Rmd
+++ b/vignettes/crisprScore.Rmd
@@ -246,14 +246,6 @@ input  <- paste0(flank5, spacer, pam, flank3)
 results <- getDeepSpCas9Scores(input)
 ```
 
-
-```{r, eval=FALSE}
-spacer  <- "ATCGATGCTGATGCTAGATA" #20bp
-pam     <- "AGG" #3bp 
-input   <- paste0(spacer, pam) 
-results <- getDeepHFScores(input)
-```
-
 Users can specify for which Cas9 they wish to score sgRNAs by using the argument
 `enzyme`: "WT" for Wildtype Cas9 (WT-SpCas9), "HF" for high-fidelity Cas9 
 (SpCas9-HF), or "ESP" for enhancedCas9 (eSpCas9). For wildtype Cas9, users can
@@ -335,7 +327,7 @@ results <- getCrispraiScores(tss_df=tssExampleCrispri,
                              sgrna_df=sgrnaExampleCrispri,
                              modality="CRISPRi",
                              fastaFile="your/path/hg38.fa",
-                             chromatinFiles=list(mnase="path/to/mnaseFile.bw",
+                             chromatinFiles=c(mnase="path/to/mnaseFile.bw",
                                                  dnase="path/to/dnaseFile.bw",
                                                  faire="oath/to/faireFile.bw"))
 ```


### PR DESCRIPTION
Due to strict channel priority, the installation of biopython encountered errors during the setup of the Conda environments for Azimuth and RuleSet3. Placing conda-forge ahead of bioconda in the channel list resolved the issue.
Additionally, minor typos in the tutorial were corrected.